### PR TITLE
Fix a bug : Object true has no method 'charAt'

### DIFF
--- a/lib/rules/validate-attribute-quote-marks.js
+++ b/lib/rules/validate-attribute-quote-marks.js
@@ -21,7 +21,7 @@ module.exports.prototype =
 
       file.iterateTokensByType('attrs', function (token) {
         token.attrs.forEach(function (attribute) {
-          var value = attribute.val
+          var value = "" + attribute.val
             , quotes = [ '"', '\'' ]
             , openingQuote = value.charAt(0)
             , closingQuote = value.charAt(value.length - 1)


### PR DESCRIPTION
Hello @benedfit 

Thank you for your GREAT TOOL!!

I encontered this error (below) when I ran jade-lint in my project.
I called jade-lint from gulp.

```
node_modules/jade-lint/lib/rules/validate-attribute-quote-marks.js:26
            , openingQuote = value.charAt(0)
                                   ^
TypeError: Object true has no method 'charAt'
    at /Users/me/myprj/node_modules/jade-lint/lib/rules/validate-attribute-quote-marks.js:26:36
    at Array.forEach (native)
    at /Users/me/myprj/node_modules/jade-lint/lib/rules/validate-attribute-quote-marks.js:23:21
    at /Users/me/myprj/node_modules/jade-lint/lib/jade-file.js:191:9
    at Array.forEach (native)
    at Object.JadeFile.iterateTokensByFilter (/Users/me/myprj/node_modules/jade-lint/lib/jade-file.js:190:38)
    at Object.JadeFile.iterateTokensByType (/Users/me/myprj/node_modules/jade-lint/lib/jade-file.js:200:12)
    at Object.module.exports.lint (/Users/me/myprj/node_modules/jade-lint/lib/rules/validate-attribute-quote-marks.js:22:12)
    at /Users/me/myprj/node_modules/jade-lint/lib/linter.js:106:14
    at Array.forEach (native)
```

This is my environment.

```
% sw_vers
ProductName:	Mac OS X
ProductVersion:	10.10.4
BuildVersion:	14E46
% node -v
v0.10.35
% npm -v
1.4.28
% gulp -v
[14:15:28] CLI version 3.8.10
```

Thanks