### PR TITLE
Resolve additional rules paths

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -112,7 +112,7 @@ Linter.prototype =
 
         this._ruleMasks.forEach(function (mask) {
           glob.sync(mask).forEach(function (file) {
-            var Rule = require(file)
+            var Rule = require(path.resolve(file))
               , rule = new Rule()
               , name = rule.name
 


### PR DESCRIPTION
Currently, additional rules are `require()`d with a path relative to `linter.js`, rather than cwd.