### PR TITLE
Cleaning documentation of 'maximumNumberOfLines'

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -247,18 +247,6 @@ input(type='text').class
 input.class(type='text')
 ```
 
-# requireClassLiteralsBeforeAttributes: `true`
-
-All class literals must be written before any attribute blocks.
-
-```jade
-//- Invalid
-input(type='text').class
-
-//- Valid
-input.class(type='text')
-```
-
 # requireClassLiteralsBeforeIdLiterals: `true`
 
 All class literals must be written before any ID literals.

--- a/lib/rules/maximum-number-of-lines.js
+++ b/lib/rules/maximum-number-of-lines.js
@@ -1,18 +1,6 @@
 // # maximumNumberOfLines: `int`
 //
 // Jade files should be at most the number of lines specified.
-//
-// # requireClassLiteralsBeforeAttributes: `true`
-//
-// All class literals must be written before any attribute blocks.
-//
-// ```jade
-// //- Invalid
-// input(type='text').class
-//
-// //- Valid
-// input.class(type='text')
-// ```
 
 var assert = require('assert')
 


### PR DESCRIPTION
Doc block for `requireClassLiteralsBeforeAttributes` rule somehow got duplicated in the file `maximum-number-of-lines.js`, causing the rule documented twice in `rules.md`. This changeset is cleaning the docs.