### PR TITLE
Cleaning documentation of 'requireLowerCaseAttributes'

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -271,18 +271,6 @@ div(Class='class')
 div(class='class')
 ```
 
-# requireLowerCaseAttributes: `true`
-
-All attributes must be written in lower case. Files with `doctype xml` are ignored.
-
-```jade
-//- Invalid
-div(Class='class')
-
-//- Valid
-div(class='class')
-```
-
 # requireLowerCaseTags: `true`
 
 All tags must be written in lower case. Files with `doctype xml` are ignored.

--- a/lib/rules/require-line-feed-at-file-end.js
+++ b/lib/rules/require-line-feed-at-file-end.js
@@ -1,18 +1,6 @@
 // # requireLineFeedAtFileEnd: `true`
 //
 // All files must end with a line feed.
-//
-// # requireLowerCaseAttributes: `true`
-//
-// All attributes must be written in lower case. Files with `doctype xml` are ignored.
-//
-// ```jade
-// //- Invalid
-// div(Class='class')
-//
-// //- Valid
-// div(class='class')
-// ```
 
 var utils = require('../utils')
 


### PR DESCRIPTION
Hey there, this is something very similar to the one on the other day, a duplicated doc block, except now it's `requireLowerCaseAttributes`.